### PR TITLE
CMakeLists.txt: message FATAL_ERROR if no suitable TLS found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ SET(HEADERS
   )
 
 IF (NOT LIBTLS_FOUND AND NOT GNUTLS_FOUND)
-  MESSAGE(ERROR "No suitable TLS implementation found")
+  MESSAGE(FATAL_ERROR "No suitable TLS implementation found")
 ENDIF()
 
 IF (LIBTLS_FOUND)


### PR DESCRIPTION
Use `FATAL_ERROR` instead of `ERROR` to fail configure stage if no suitable TLS implementation