### PR TITLE
message.c: add support for tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ SET(SOURCES
   "lib/util.c"
   "lib/config.c"
   "lib/ssl.h"
+  "lib/tag.c"
   "${CMAKE_CURRENT_BINARY_DIR}/config_parse.c"
   "${CMAKE_CURRENT_BINARY_DIR}/config_lex.c"
   )
@@ -56,6 +57,7 @@ SET(HEADERS
   "irc/util.h"
   "irc/config.h"
   "irc/message.h"
+  "irc/tag.h"
   )
 
 IF (NOT LIBTLS_FOUND AND NOT GNUTLS_FOUND)

--- a/irc/message.h
+++ b/irc/message.h
@@ -2,6 +2,7 @@
 #define LIBIRC_MESSAGE_H
 
 #include <irc/error.h>
+#include <irc/tag.h>
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -23,6 +24,8 @@ struct irc_message_
     char *command;
     char **args;
     size_t argslen;
+    irc_tag_t *tags;
+    size_t tagslen;
 };
 
 typedef struct irc_message_ *irc_message_t;

--- a/irc/tag.h
+++ b/irc/tag.h
@@ -1,0 +1,22 @@
+#ifndef LIBIRC_TAG_H
+#define LIBIRC_TAG_H
+
+#include <irc/error.h>
+
+#include <stddef.h>
+
+struct irc_tag_
+{
+    char *key;
+    char *value;
+};
+typedef struct irc_tag_ *irc_tag_t;
+
+irc_tag_t irc_tag_new(void);
+void irc_tag_free(irc_tag_t t);
+
+irc_error_t irc_tag_parse(irc_tag_t t, const char *str);
+
+char *irc_tag_unescape(const char *value);
+
+#endif

--- a/lib/tag.c
+++ b/lib/tag.c
@@ -1,0 +1,109 @@
+#include <irc/tag.h>
+#include <irc/strbuf.h>
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+irc_tag_t irc_tag_new(void)
+{
+    irc_tag_t t = NULL;
+
+    t = calloc(1, sizeof(struct irc_tag_));
+    if (!t) {
+        return NULL;
+    }
+
+    return t;
+}
+
+void irc_tag_free(irc_tag_t t)
+{
+    if (t == NULL) {
+        return;
+    }
+
+    free(t->key);
+    t->key = NULL;
+
+    free(t->value);
+    t->value = NULL;
+
+    free(t);
+}
+
+irc_error_t irc_tag_parse(irc_tag_t t, const char *str)
+{
+    char *tmp = NULL;
+    char *key = NULL;
+    char *value = NULL;
+
+    if (t == NULL || str == NULL) {
+        return irc_error_argument;
+    }
+
+    tmp = strdup(str);
+    key = strsep(&tmp, "=");
+    if (key == NULL) {
+        return irc_error_parse;
+    }
+    t->key = strdup(key);
+    t->value = irc_tag_unescape(tmp);
+
+    return irc_error_success;
+}
+
+char *irc_tag_unescape(const char *value)
+{
+    char *ret = NULL;
+    strbuf_t unescaped = NULL;
+
+    unescaped = strbuf_new();
+
+    while (value && value[0]) {
+        switch(value[0]) {
+        case '\\':
+            value++;
+            switch(value[0]) {
+            case ':':
+                strbuf_append(unescaped, ";", 1);
+                value++;
+                break;
+            case 's':;
+                strbuf_append(unescaped, " ", 1);
+                value++;
+                break;
+            case '\\':
+                strbuf_append(unescaped, "\\", 1);
+                value++;
+                break;
+            case 'r':
+                strbuf_append(unescaped, "\r", 1);
+                value++;
+                break;
+            case 'n':
+                strbuf_append(unescaped, "\n", 1);
+                value++;
+                break;
+            default:
+                if (value[0]) {
+                    strbuf_append(unescaped, &value[0], 1);
+                    value++;
+                }
+                break;
+            }
+            break;
+        default:
+            strbuf_append(unescaped, &value[0], 1);
+            value++;
+            break;
+        }
+    }
+
+    if (strbuf_len(unescaped) > 0) {
+        ret = strbuf_strdup(unescaped);
+    }
+    strbuf_free(unescaped);
+
+    return ret;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,9 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
 
 SET(TESTS
+  "test_message"
   "test_strbuf"
+  "test_tag"
   )
 
 INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/..")

--- a/tests/test_message.c
+++ b/tests/test_message.c
@@ -1,0 +1,78 @@
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include <irc/message.h>
+
+static void test_message_parse_without_tag(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *str = ":prefix COMMAND Arg";
+    irc_error_t error = irc_error_internal;
+
+    error = irc_message_parse(m, str, strlen(str));
+    assert_int_equal(error, irc_error_success);
+    assert_string_equal(m->prefix, "prefix");
+    assert_string_equal(m->command, "COMMAND");
+    assert_int_equal(m->argslen, 1);
+    assert_string_equal(m->args[0], "Arg");
+    assert_int_equal(m->tagslen, 0);
+    assert_ptr_equal(m->tags, NULL);
+
+    irc_message_unref(m);
+}
+
+static void test_message_parse_with_single_tag(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *str = "@time=0000 :prefix COMMAND Arg";
+    irc_error_t error = irc_error_internal;
+
+    error = irc_message_parse(m, str, strlen(str));
+    assert_int_equal(error, irc_error_success);
+    assert_string_equal(m->prefix, "prefix");
+    assert_string_equal(m->command, "COMMAND");
+    assert_int_equal(m->argslen, 1);
+    assert_string_equal(m->args[0], "Arg");
+    assert_int_equal(m->tagslen, 1);
+    assert_string_equal(m->tags[0]->key, "time");
+    assert_string_equal(m->tags[0]->value, "0000");
+
+    irc_message_unref(m);
+}
+
+static void test_message_parse_with_multiple_tag(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *str = "@key1=value1;key2;key3=value3 :prefix COMMAND Arg";
+    irc_error_t error = irc_error_internal;
+
+    error = irc_message_parse(m, str, strlen(str));
+    assert_int_equal(error, irc_error_success);
+    assert_string_equal(m->prefix, "prefix");
+    assert_string_equal(m->command, "COMMAND");
+    assert_int_equal(m->argslen, 1);
+    assert_string_equal(m->args[0], "Arg");
+    assert_int_equal(m->tagslen, 3);
+    assert_string_equal(m->tags[0]->key, "key1");
+    assert_string_equal(m->tags[0]->value, "value1");
+    assert_string_equal(m->tags[1]->key, "key2");
+    assert_ptr_equal(m->tags[1]->value, NULL);
+    assert_string_equal(m->tags[2]->key, "key3");
+    assert_string_equal(m->tags[2]->value, "value3");
+
+    irc_message_unref(m);
+}
+
+int main(int ac, char **av)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_message_parse_without_tag),
+        cmocka_unit_test(test_message_parse_with_single_tag),
+        cmocka_unit_test(test_message_parse_with_multiple_tag),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/test_tag.c
+++ b/tests/test_tag.c
@@ -1,0 +1,87 @@
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <cmocka.h>
+
+#include <irc/tag.h>
+
+static int setup(void **data)
+{
+    irc_tag_t t = irc_tag_new();
+    if (t == NULL) {
+        return -1;
+    }
+
+    *data = t;
+
+    return 0;
+}
+
+static int teardown(void **data)
+{
+    irc_tag_free(*data);
+
+    return 0;
+}
+
+static void test_tag_parse_no_value(void **data)
+{
+    irc_tag_t t = *data;
+    const char *str = "key";
+    irc_error_t error = irc_error_internal;
+
+    assert_ptr_not_equal(t, NULL);
+    error = irc_tag_parse(t, str);
+    assert_return_code(error, irc_error_success);
+    assert_string_equal(t->key, "key");
+    assert_ptr_equal(t->value, NULL);
+}
+
+static void test_tag_parse_single(void **data)
+{
+    irc_tag_t t = *data;
+    const char *str = "key=value";
+    irc_error_t error = irc_error_internal;
+
+    assert_ptr_not_equal(t, NULL);
+    error = irc_tag_parse(t, str);
+    assert_return_code(error, irc_error_success);
+    assert_string_equal(t->key, "key");
+    assert_string_equal(t->value, "value");
+}
+
+#define ASSERT_TAG_UNSESCAPED(STR, EXPECTED) \
+    unscaped = irc_tag_unescape(STR); \
+    assert_string_equal(unscaped, EXPECTED); \
+    free(unscaped)
+
+static void test_tag_unescape(void **data)
+{
+    irc_tag_t t = *data;
+    char *unscaped = NULL;
+
+    ASSERT_TAG_UNSESCAPED ("\\:", ";");
+    ASSERT_TAG_UNSESCAPED ("\\s", " ");
+    ASSERT_TAG_UNSESCAPED ("\\\\", "\\");
+    ASSERT_TAG_UNSESCAPED ("\\r", "\r");
+    ASSERT_TAG_UNSESCAPED ("\\n", "\n");
+    ASSERT_TAG_UNSESCAPED ("test", "test");
+    ASSERT_TAG_UNSESCAPED ("test\\", "test");
+    ASSERT_TAG_UNSESCAPED ("test\\b", "testb");
+    ASSERT_TAG_UNSESCAPED ("\\:\\s\\\\\\r\\n", "; \\\r\n");
+}
+
+int main(int ac, char **av)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_tag_parse_no_value, setup,
+                                        teardown),
+        cmocka_unit_test_setup_teardown(test_tag_parse_single, setup, teardown),
+        cmocka_unit_test(test_tag_unescape),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This adds support to parse [message tags](https://ircv3.net/specs/extensions/message-tags) from a message.

Let me know if you would see it implemented in some other way or have any other comments.