### PR TITLE
Include tags in irc_message_string() output

### DIFF
--- a/irc/tag.h
+++ b/irc/tag.h
@@ -17,6 +17,8 @@ void irc_tag_free(irc_tag_t t);
 
 irc_error_t irc_tag_parse(irc_tag_t t, char const *str);
 
+irc_tag_t irc_tag_make(char const *key, char const *value);
+
 irc_error_t irc_tag_string(irc_tag_t t, char **s, size_t *slen);
 
 char *irc_tag_unescape(char const *value);

--- a/irc/tag.h
+++ b/irc/tag.h
@@ -18,5 +18,6 @@ void irc_tag_free(irc_tag_t t);
 irc_error_t irc_tag_parse(irc_tag_t t, char const *str);
 
 char *irc_tag_unescape(char const *value);
+char *irc_tag_escape(char const *value);
 
 #endif

--- a/irc/tag.h
+++ b/irc/tag.h
@@ -17,6 +17,8 @@ void irc_tag_free(irc_tag_t t);
 
 irc_error_t irc_tag_parse(irc_tag_t t, char const *str);
 
+irc_error_t irc_tag_string(irc_tag_t t, char **s, size_t *slen);
+
 char *irc_tag_unescape(char const *value);
 char *irc_tag_escape(char const *value);
 

--- a/irc/tag.h
+++ b/irc/tag.h
@@ -15,8 +15,8 @@ typedef struct irc_tag_ *irc_tag_t;
 irc_tag_t irc_tag_new(void);
 void irc_tag_free(irc_tag_t t);
 
-irc_error_t irc_tag_parse(irc_tag_t t, const char *str);
+irc_error_t irc_tag_parse(irc_tag_t t, char const *str);
 
-char *irc_tag_unescape(const char *value);
+char *irc_tag_unescape(char const *value);
 
 #endif

--- a/lib/message.c
+++ b/lib/message.c
@@ -117,8 +117,7 @@ irc_error_t irc_message_parse(irc_message_t c, char const *l, size_t len)
             continue;
         }
 
-        switch (i)
-        {
+        switch (i) {
         case 0:
         {
             /* check if we actually have tags or a prefix. Tags start with '@'
@@ -299,6 +298,29 @@ irc_error_t irc_message_string(irc_message_t m, char **s, size_t *slen)
     buf = strbuf_new();
     if (buf == NULL) {
         return irc_error_memory;
+    }
+
+    if (m->tagslen > 0) {
+        strbuf_append(buf, "@", 1);
+        for (size_t i = 0; i < m->tagslen; i++) {
+            irc_error_t error = irc_error_internal;
+            char *str = NULL;
+            size_t len = 0;
+
+            error = irc_tag_string(m->tags[i], &str, &len);
+            if (IRC_FAILED(error)) {
+                strbuf_free(buf);
+                free(str);
+                return error;
+            } else {
+                strbuf_append(buf, str, len);
+            }
+            free(str);
+
+            if (i + 1 < m->tagslen)
+                strbuf_append(buf, ";", 1);
+        }
+        strbuf_append(buf, " ", 1);
     }
 
     if (m->prefix) {

--- a/lib/tag.c
+++ b/lib/tag.c
@@ -57,6 +57,33 @@ irc_error_t irc_tag_parse(irc_tag_t t, char const *str)
     return irc_error_success;
 }
 
+irc_error_t irc_tag_string(irc_tag_t t, char **s, size_t *slen)
+{
+    strbuf_t buf = NULL;
+
+    if (t == NULL || t->key == NULL || s == NULL) {
+        return irc_error_argument;
+    }
+
+    buf = strbuf_new();
+    strbuf_append(buf, t->key, strlen(t->key));
+    if (t->value != NULL) {
+        char *value = irc_tag_escape(t->value);
+
+        strbuf_append(buf, "=", 1);
+        strbuf_append(buf, value, strlen(value));
+        free(value);
+    }
+
+    *s = strbuf_strdup (buf);
+    if (slen != NULL) {
+        *slen = strbuf_len(buf);
+    }
+    strbuf_free(buf);
+
+    return irc_error_success;
+}
+
 char *irc_tag_unescape(char const *value)
 {
     char *ret = NULL;

--- a/lib/tag.c
+++ b/lib/tag.c
@@ -32,7 +32,7 @@ void irc_tag_free(irc_tag_t t)
     free(t);
 }
 
-irc_error_t irc_tag_parse(irc_tag_t t, const char *str)
+irc_error_t irc_tag_parse(irc_tag_t t, char const *str)
 {
     char *ptr = NULL;
     char *value = NULL;
@@ -57,7 +57,7 @@ irc_error_t irc_tag_parse(irc_tag_t t, const char *str)
     return irc_error_success;
 }
 
-char *irc_tag_unescape(const char *value)
+char *irc_tag_unescape(char const *value)
 {
     char *ret = NULL;
     strbuf_t unescaped = NULL;

--- a/lib/tag.c
+++ b/lib/tag.c
@@ -57,6 +57,27 @@ irc_error_t irc_tag_parse(irc_tag_t t, char const *str)
     return irc_error_success;
 }
 
+irc_tag_t irc_tag_make(char const *key, char const *value)
+{
+    irc_tag_t t = NULL;
+
+    if (key == NULL) {
+        return NULL;
+    }
+
+    t = irc_tag_new();
+    if (t == NULL) {
+        return NULL;
+    }
+
+    t->key = strdup(key);
+    if (value != NULL) {
+        t->value = strdup(value);
+    }
+
+    return t;
+}
+
 irc_error_t irc_tag_string(irc_tag_t t, char **s, size_t *slen)
 {
     strbuf_t buf = NULL;

--- a/lib/tag.c
+++ b/lib/tag.c
@@ -65,10 +65,10 @@ char *irc_tag_unescape(char const *value)
     unescaped = strbuf_new();
 
     while (value && value[0]) {
-        switch(value[0]) {
+        switch (value[0]) {
         case '\\':
             value++;
-            switch(value[0]) {
+            switch (value[0]) {
             case ':':
                 strbuf_append(unescaped, ";", 1);
                 value++;
@@ -108,6 +108,43 @@ char *irc_tag_unescape(char const *value)
         ret = strbuf_strdup(unescaped);
     }
     strbuf_free(unescaped);
+
+    return ret;
+}
+
+char *irc_tag_escape(char const *value)
+{
+    char *ret = NULL;
+    strbuf_t escaped = NULL;
+
+    escaped = strbuf_new();
+
+    while (value && value[0]) {
+        switch (value[0]) {
+        case ';':
+            strbuf_append(escaped, "\\:", 2);
+            break;
+        case ' ':
+            strbuf_append(escaped, "\\s", 2);
+            break;
+        case '\\':
+            strbuf_append(escaped, "\\\\", 2);
+            break;
+        case '\r':
+            strbuf_append(escaped, "\\r", 2);
+            break;
+        case '\n':
+            strbuf_append(escaped, "\\n", 2);
+            break;
+        default:
+            strbuf_append(escaped, value, 1);
+            break;
+        }
+        value++;
+    }
+
+    ret = strbuf_strdup(escaped);
+    strbuf_free(escaped);
 
     return ret;
 }

--- a/tests/test_message.c
+++ b/tests/test_message.c
@@ -66,12 +66,37 @@ static void test_message_parse_with_multiple_tag(void **data)
     irc_message_unref(m);
 }
 
+static void test_message_string(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *expected = "@key1=value1;key2=value2 :prefix COMMAND Arg\r\n";
+    char *str = NULL;
+    irc_error_t error = irc_error_internal;
+    char *actual = NULL;
+    size_t len = 0;
+
+    // Allocate string for parsing without the "\r\n"
+    str = calloc(sizeof(char), strlen(expected) - 1);
+    memcpy(str, expected, strlen(expected) - 2);
+    error = irc_message_parse(m, str, strlen(str));
+    assert_return_code(error, irc_error_success);
+
+    error = irc_message_string(m, &actual, &len);
+    assert_return_code(error, irc_error_success);
+    assert_string_equal(actual, expected);
+
+    free(str);
+    free(actual);
+    irc_message_unref(m);
+}
+
 int main(int ac, char **av)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_message_parse_without_tag),
         cmocka_unit_test(test_message_parse_with_single_tag),
         cmocka_unit_test(test_message_parse_with_multiple_tag),
+        cmocka_unit_test(test_message_string),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/test_tag.c
+++ b/tests/test_tag.c
@@ -73,6 +73,24 @@ static void test_tag_unescape(void **data)
     ASSERT_TAG_UNSESCAPED ("\\:\\s\\\\\\r\\n", "; \\\r\n");
 }
 
+#define ASSERT_TAG_ESCAPED(STR, EXPECTED) \
+    escaped = irc_tag_escape(STR); \
+    assert_string_equal(escaped, EXPECTED); \
+    free(escaped);
+
+static void test_tag_escape(void **data)
+{
+    char *escaped = NULL;
+
+    ASSERT_TAG_ESCAPED(";", "\\:");
+    ASSERT_TAG_ESCAPED(" ", "\\s");
+    ASSERT_TAG_ESCAPED("\\", "\\\\");
+    ASSERT_TAG_ESCAPED("\r", "\\r");
+    ASSERT_TAG_ESCAPED("\n", "\\n");
+    ASSERT_TAG_ESCAPED("test", "test");
+    ASSERT_TAG_ESCAPED("; \\\r\n", "\\:\\s\\\\\\r\\n");
+}
+
 int main(int ac, char **av)
 {
     const struct CMUnitTest tests[] = {
@@ -80,6 +98,7 @@ int main(int ac, char **av)
                                         teardown),
         cmocka_unit_test_setup_teardown(test_tag_parse_single, setup, teardown),
         cmocka_unit_test(test_tag_unescape),
+        cmocka_unit_test(test_tag_escape),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
With these changes the `irc_message_string()` will include the tags in the output if the `irc_message_t` contains tags.