### PR TITLE
Respect "len" parameter in irc_message_parse()

### DIFF
--- a/lib/irc.c
+++ b/lib/irc.c
@@ -248,7 +248,6 @@ static irc_error_t irc_think_data(irc_t i)
     /* strip \r\n from the line
      */
     if (linesize > 2) {
-        line[linesize-2] = '\0';
         linesize -= 2;
     }
 

--- a/lib/message.c
+++ b/lib/message.c
@@ -105,7 +105,7 @@ irc_error_t irc_message_parse(irc_message_t c, char const *l, size_t len)
     irc_tag_t *tags = NULL;
     size_t tagslen = 0;
 
-    char *line = strdup(l);
+    char *line = len < 0 ? strdup(l) : strndup(l, len);
     char *ptr = line;
     char *part = NULL;
     irc_error_t r = irc_error_memory;

--- a/tests/test_message.c
+++ b/tests/test_message.c
@@ -12,7 +12,7 @@ static void test_message_parse_without_tag(void **data)
     const char *str = ":prefix COMMAND Arg";
     irc_error_t error = irc_error_internal;
 
-    error = irc_message_parse(m, str, strlen(str));
+    error = irc_message_parse(m, str, -1);
     assert_int_equal(error, irc_error_success);
     assert_string_equal(m->prefix, "prefix");
     assert_string_equal(m->command, "COMMAND");
@@ -30,7 +30,7 @@ static void test_message_parse_with_single_tag(void **data)
     const char *str = "@time=0000 :prefix COMMAND Arg";
     irc_error_t error = irc_error_internal;
 
-    error = irc_message_parse(m, str, strlen(str));
+    error = irc_message_parse(m, str, -1);
     assert_int_equal(error, irc_error_success);
     assert_string_equal(m->prefix, "prefix");
     assert_string_equal(m->command, "COMMAND");
@@ -49,7 +49,7 @@ static void test_message_parse_with_multiple_tag(void **data)
     const char *str = "@key1=value1;key2;key3=value3 :prefix COMMAND Arg";
     irc_error_t error = irc_error_internal;
 
-    error = irc_message_parse(m, str, strlen(str));
+    error = irc_message_parse(m, str, -1);
     assert_int_equal(error, irc_error_success);
     assert_string_equal(m->prefix, "prefix");
     assert_string_equal(m->command, "COMMAND");
@@ -70,22 +70,18 @@ static void test_message_string(void **data)
 {
     irc_message_t m = irc_message_new();
     const char *expected = "@key1=value1;key2=value2 :prefix COMMAND Arg\r\n";
-    char *str = NULL;
     irc_error_t error = irc_error_internal;
     char *actual = NULL;
     size_t len = 0;
 
-    // Allocate string for parsing without the "\r\n"
-    str = calloc(sizeof(char), strlen(expected) - 1);
-    memcpy(str, expected, strlen(expected) - 2);
-    error = irc_message_parse(m, str, strlen(str));
+    // Pass length minus the "\r\n"
+    error = irc_message_parse(m, expected, strlen(expected) - 2);
     assert_return_code(error, irc_error_success);
 
     error = irc_message_string(m, &actual, &len);
     assert_return_code(error, irc_error_success);
     assert_string_equal(actual, expected);
 
-    free(str);
     free(actual);
     irc_message_unref(m);
 }


### PR DESCRIPTION
This allows to parse message only by passing length, i.e. the `line` does not need to be null terminated to the wanted length or at all.

If `len` is `-1` then the whole `line` is parsed which in that case should be a null-terminated string.