### PR TITLE
Fix parsing message with parameter containg spaces

### DIFF
--- a/tests/test_message.c
+++ b/tests/test_message.c
@@ -24,6 +24,45 @@ static void test_message_parse_without_tag(void **data)
     irc_message_unref(m);
 }
 
+static void test_message_parse_with_parameter_containing_spaces(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *str = ":guest PRIVMSG #channel :haha :D";
+    irc_error_t error = irc_error_internal;
+
+    error = irc_message_parse(m, str, -1);
+    assert_return_code (error, irc_error_success);
+    assert_string_equal(m->prefix, "guest");
+    assert_string_equal(m->command, "PRIVMSG");
+    assert_int_equal(m->argslen, 2);
+    assert_string_equal(m->args[0], "#channel");
+    assert_string_equal(m->args[1], "haha :D");
+    assert_int_equal(m->tagslen, 0);
+    assert_ptr_equal(m->tags, NULL);
+
+    irc_message_unref(m);
+}
+
+static void test_message_parse_with_parameters(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *str = ":guest COMMAND param1 param2 :param3 with spaces";
+    irc_error_t error = irc_error_internal;
+
+    error = irc_message_parse(m, str, -1);
+    assert_return_code(error, irc_error_success);
+    assert_string_equal(m->prefix, "guest");
+    assert_string_equal(m->command, "COMMAND");
+    assert_int_equal(m->argslen, 3);
+    assert_string_equal(m->args[0], "param1");
+    assert_string_equal(m->args[1], "param2");
+    assert_string_equal(m->args[2], "param3 with spaces");
+    assert_int_equal(m->tagslen, 0);
+    assert_ptr_equal(m->tags, NULL);
+
+    irc_message_unref(m);
+}
+
 static void test_message_parse_with_single_tag(void **data)
 {
     irc_message_t m = irc_message_new();
@@ -86,13 +125,38 @@ static void test_message_string(void **data)
     irc_message_unref(m);
 }
 
+static void test_message_string_with_semicolon(void **data)
+{
+    irc_message_t m = irc_message_new();
+    const char *expected = ":prefix PRIVMSG #channel :A smiley :) and text\r\n";
+    irc_error_t error = irc_error_internal;
+    char *actual = NULL;
+    size_t len = 0;
+
+    // Pass length minus the "\r\n"
+    error = irc_message_parse(m, expected, strlen(expected) - 2);
+    assert_int_equal (m->argslen, 2);
+    assert_string_equal(m->args[1], "A smiley :) and text");
+    assert_return_code (error, irc_error_success);
+
+    error = irc_message_string(m, &actual, &len);
+    assert_return_code (error, irc_error_success);
+    assert_string_equal(actual, expected);
+
+    free(actual);
+    irc_message_unref(m);
+}
+
 int main(int ac, char **av)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test(test_message_parse_without_tag),
+        cmocka_unit_test(test_message_parse_with_parameter_containing_spaces),
+        cmocka_unit_test(test_message_parse_with_parameters),
         cmocka_unit_test(test_message_parse_with_single_tag),
         cmocka_unit_test(test_message_parse_with_multiple_tag),
         cmocka_unit_test(test_message_string),
+        cmocka_unit_test(test_message_string_with_semicolon),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
The other day I noticed that `PRIVMSG` received were missing `:` character, e.g. when some one sents `haha :D` and it's parsed and converted to string the message is `haha D` (the raw message is something like `... PRIVMSG :haha :D`).

I think this is due the parameters are not parsed according the specification. The official [specification](https://www.rfc-editor.org/rfc/rfc1459#section-2.3.1) doesn't specify it so verbosely but "modern" reference spec states about [parameters](https://modern.ircdocs.horse/#parameters):

> Parameters are a series of values separated by one or more ASCII SPACE characters (' ', 0x20). However, this syntax is insufficient in two cases: a parameter that contains one or more spaces, and an empty parameter. To permit such parameters, the final parameter can be prepended with a (':', 0x3A) character, in which case that character is stripped and the rest of the message is treated as the final parameter, including any spaces it contains.

This PR should address this and make the parsing work according the specification (unless I missed something?).